### PR TITLE
codesign: always use supplied resource-directory hash if applicable

### DIFF
--- a/export.go
+++ b/export.go
@@ -258,6 +258,10 @@ func (f *File) CodeSign(config *codesign.Config) error {
 		return fmt.Errorf("failed to find __LINKEDIT segment")
 	}
 
+	if config.ResourceDirSlotHash != nil {
+		config.SlotHashes.ResourceDir = config.ResourceDirSlotHash
+	}
+
 	if cs = f.CodeSignature(); cs != nil { // existing code signature
 		// import settings from existing code signature
 		if len(cs.CodeDirectories) > 0 {
@@ -275,9 +279,6 @@ func (f *File) CodeSign(config *codesign.Config) error {
 			}
 			if config.EntitlementsDER == nil {
 				config.EntitlementsDER = []byte(cs.EntitlementsDER)
-			}
-			if config.ResourceDirSlotHash != nil {
-				config.SlotHashes.ResourceDir = config.ResourceDirSlotHash
 			}
 			if config.SpecialSlots == nil {
 				config.SpecialSlots = cs.CodeDirectories[0].SpecialSlots


### PR DESCRIPTION
The supplied resource directory slot hash was previously only being used when signing a binary that already had a code signature. There's no reason not to use it when creating a brand-new code signature, so this change does that.