### PR TITLE
codesign: add support for RUNTIME flag and minimum runtime version

### DIFF
--- a/export.go
+++ b/export.go
@@ -283,7 +283,13 @@ func (f *File) CodeSign(config *codesign.Config) error {
 				config.SpecialSlots = cs.CodeDirectories[0].SpecialSlots
 			}
 			if config.RuntimeVersion == 0 {
-				config.RuntimeVersion = cs.CodeDirectories[0].Header.Runtime
+				if cs.CodeDirectories[0].Header.Runtime != 0 {
+					config.RuntimeVersion = cs.CodeDirectories[0].Header.Runtime
+				} else if bv := f.BuildVersion(); bv != nil {
+					config.RuntimeVersion = bv.Sdk
+				} else if vm := f.VersionMin(); vm != nil {
+					config.RuntimeVersion = vm.Sdk
+				}
 			}
 		}
 	} else { // create NEW code signature

--- a/file.go
+++ b/file.go
@@ -1735,6 +1735,23 @@ func (f *File) BuildVersion() *BuildVersion {
 	return nil
 }
 
+// VersionMin returns the minimum-version load command, or nil if no minimum-version exists.
+func (f *File) VersionMin() *VersionMin {
+	for _, l := range f.Loads {
+		switch s := l.(type) {
+		case *VersionMinMacOSX:
+			return &s.VersionMin
+		case *VersionMinTvOS:
+			return &s.VersionMin
+		case *VersionMinWatchOS:
+			return &s.VersionMin
+		case *VersionMiniPhoneOS:
+			return &s.VersionMin
+		}
+	}
+	return nil
+}
+
 // FileSets returns an array of Fileset entries.
 func (f *File) FileSets() []*FilesetEntry {
 	var fsets []*FilesetEntry

--- a/pkg/codesign/codesign.go
+++ b/pkg/codesign/codesign.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"strings"
 
+	mtypes "github.com/blacktop/go-macho/types"
 	"github.com/blacktop/go-macho/pkg/codesign/types"
 )
 
@@ -434,6 +435,7 @@ type Config struct {
 	EntitlementsDER     []byte
 	ResourceDirSlotHash []byte
 	SlotHashes          slotHashes
+	RuntimeVersion mtypes.Version
 	CertChain           []*x509.Certificate
 	SignerFunction      func([]byte) ([]byte, error)
 }
@@ -597,7 +599,7 @@ func createCodeDirectory(r io.Reader, config *Config) (*bytes.Buffer, error) {
 
 	cdHeader := types.CodeDirectoryType{
 		CdEarliest: types.CdEarliest{
-			Version:       types.SUPPORTS_EXECSEG, // TODO: support other versions (e.g.SUPPORTS_RUNTIME)
+			Version:       types.SUPPORTS_RUNTIME, // TODO: support other versions (e.g.SUPPORTS_LINKAGE)
 			Flags:         config.Flags,
 			HashOffset:    hashOffset,
 			IdentOffset:   identOffset,
@@ -611,6 +613,9 @@ func createCodeDirectory(r io.Reader, config *Config) (*bytes.Buffer, error) {
 		CdExecSeg: types.CdExecSeg{
 			ExecSegBase:  uint64(config.TextOffset),
 			ExecSegLimit: uint64(config.TextSize),
+		},
+		CdRuntime: types.CdRuntime{
+			Runtime: config.RuntimeVersion,
 		},
 	}
 

--- a/pkg/codesign/codesign.go
+++ b/pkg/codesign/codesign.go
@@ -12,8 +12,8 @@ import (
 	"io"
 	"strings"
 
-	mtypes "github.com/blacktop/go-macho/types"
 	"github.com/blacktop/go-macho/pkg/codesign/types"
+	mtypes "github.com/blacktop/go-macho/types"
 )
 
 // CodeSignature object
@@ -435,7 +435,7 @@ type Config struct {
 	EntitlementsDER     []byte
 	ResourceDirSlotHash []byte
 	SlotHashes          slotHashes
-	RuntimeVersion mtypes.Version
+	RuntimeVersion      mtypes.Version
 	CertChain           []*x509.Certificate
 	SignerFunction      func([]byte) ([]byte, error)
 }


### PR DESCRIPTION
This change adds support for the RUNTIME code signature flag, which requires a hardened runtime and allows the binary to require a particular runtime version.