### PR TITLE
codesign: more conservative estimate of signature sizes

### DIFF
--- a/export.go
+++ b/export.go
@@ -310,7 +310,7 @@ func (f *File) CodeSign(config *codesign.Config) error {
 	f.ledata = bytes.NewBuffer(ledata[:(uint64(cs.Offset) - linkedit.Offset)])
 
 	// update __LINKEDIT segment sizes
-	linkedit.Filesz = pageAlign(uint64(len(ledata)), 0x4000) // TODO: is this enough padding to hold the new signature?
+	linkedit.Filesz = pageAlign(uint64(len(ledata)) + codesign.EstimateCodeSignatureSize(config), 0x4000)
 	linkedit.Memsz = pageAlign(linkedit.Filesz, 0x8000)
 	// update LC_CODE_SIGNATURE size
 	cs.Size = uint32((linkedit.Offset + linkedit.Filesz) - uint64(cs.Offset))


### PR DESCRIPTION
Mach-O code signing has a circular dependency problem: the code signature includes hashes that cover the link editing load-command which specifies the size of the code signature. Therefore we need to know the code signature's size before we generate it!

A proper code signature contains some potentially-rather-large components: the code hashes are proportional to the size of the binary itself, and the CMS signature can grow quite large because it includes the full signing certificate chain as well as a timestamp from the Apple timestamp service. This change computes a (somewhat conservative, but reasonable) estimate of code-signature size rather than merely aligning up to the nearest 16KiB boundary.