### PR TITLE
requirements: correctly interpret apple cert requirements

### DIFF
--- a/pkg/codesign/types/requirement.go
+++ b/pkg/codesign/types/requirement.go
@@ -644,7 +644,7 @@ func CreateRequirements(id string, certs []*x509.Certificate) (Blob, error) {
 					ops = append(ops, leafCertIndex)
 					ops = append(ops, encodeBytes([]byte("subject.CN"))...)
 					ops = append(ops, uint32(matchEqual))
-					ops = append(ops, encodeBytes([]byte(leafCert.Subject.OrganizationalUnit[0]))...)
+					ops = append(ops, encodeBytes([]byte(leafCert.Subject.CommonName))...)
 					statements = append(statements, ops)
 				}
 			}

--- a/pkg/codesign/types/requirement.go
+++ b/pkg/codesign/types/requirement.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/blacktop/go-macho/pkg/trie"
 	mtypes "github.com/blacktop/go-macho/types"
 )
 
@@ -692,12 +691,11 @@ func CreateRequirements(id string, certs []*x509.Certificate) (Blob, error) {
 }
 
 func encodeOID(oid asn1.ObjectIdentifier) []byte {
-	var res bytes.Buffer
-	trie.EncodeUleb128(&res, uint64(oid[0])*40+uint64(oid[1]))
-	for _, v := range oid[2:] {
-		trie.EncodeUleb128(&res, uint64(v))
+	res, err := asn1.Marshal(oid)
+	if err != nil {
+		panic(fmt.Errorf("asn1.Marshal could not marshal object identifier %v: %w", oid, err))
 	}
-	return res.Bytes()
+	return res[2:]				// strip leading type tag and length
 }
 
 func encodeBytes(in []byte) []uint32 {


### PR DESCRIPTION
This change makes the inference of Designated Requirements from an Apple code-signing certificate chain more closely match the official Apple `codesign` tool:

- certs signed with a "developer id application" CA add a requirement for a signature by such a CA, a requirement for the leaf cert to have a "developer id application" extension (which we only add if the leaf cert in use does indeed have that extension), and bind the OU found the leaf cert

- certs signed with a "worldwide developer relations" CA (i.e., developer certificates) add a requirement for that CA extension, and bind the CN rather than the OU from the leaf cert

This is important because two binaries must have identical Designated Requirements in order to be considered the same application by macOS.