### PR TITLE
fix: omit dynamic from property attributes

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -229,7 +229,7 @@ func getPropertyAttributeTypes(attrs string) (string, bool) {
 		case propertyWeak:
 			attrsList = append(attrsList, "weak")
 		case propertyDynamic:
-			attrsList = append(attrsList, "@dynamic")
+			// attrsList = append(attrsList, "@dynamic")
 		case propertyStrong:
 			attrsList = append(attrsList, "collectable")
 		case propertyOptional:

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -229,7 +229,8 @@ func getPropertyAttributeTypes(attrs string) (string, bool) {
 		case propertyWeak:
 			attrsList = append(attrsList, "weak")
 		case propertyDynamic:
-			// attrsList = append(attrsList, "@dynamic")
+			// omit the @dynamic directive because it must never appear inside
+			// @interface and @protocol blocks, only in @implementation blocks
 		case propertyStrong:
 			attrsList = append(attrsList, "collectable")
 		case propertyOptional:


### PR DESCRIPTION
`@dynamic` is only meant to be used inside an `@implementation` block, it should never appear inside `@interface` and `@protocol` blocks. This patch prevents go-macho from generating a header with that attribute.

Before:

```objc
@interface AXAuditTimedResult : NSObject

@property (retain, nonatomic) NSDate *startTime;
@property (retain, nonatomic) NSDate *endTime;
@property (readonly, @dynamic, nonatomic) NSString *executionTimeString;

@end
```

After:
```objc
@interface AXAuditTimedResult : NSObject

@property (retain, nonatomic) NSDate *startTime;
@property (retain, nonatomic) NSDate *endTime;
@property (readonly, nonatomic) NSString *executionTimeString;

@end
```