### PR TITLE
fix: type encoding when implementing multiple protocols

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -181,7 +181,7 @@ func getPropertyType(attrs string) (typ string) {
 		if strings.HasPrefix(attr, "@\"") {
 			typ = strings.Trim(attr, "@\"")
 			if strings.HasPrefix(typ, "<") {
-				typ = "NSObject" + typ
+				typ = "NSObject" + strings.ReplaceAll(typ, "><", ", ")
 			}
 			typ += " *"
 		} else {
@@ -248,7 +248,7 @@ func getIVarType(ivType string) string {
 	if strings.HasPrefix(ivType, "@\"") && len(ivType) > 1 {
 		ivType = strings.Trim(ivType, "@\"")
 		if strings.HasPrefix(ivType, "<") {
-			ivType = "NSObject" + ivType
+			ivType = "NSObject" + strings.ReplaceAll(ivType, "><", ", ")
 		}
 		return ivType + " *"
 	}


### PR DESCRIPTION
When a type the implements multiple protocols, go-macho doesn't encode it properly. This patch addresses this issue.

Before:
```objc
@protocol APMetricNotificationRegisterOwner <NSObject>

@property (readonly, nonatomic) NSObject<APMetricNotificationRegister><APMetricReceiving> *notificationRegistrar;

@end
```

After:
```objc
@protocol APMetricNotificationRegisterOwner <NSObject>

@property (readonly, nonatomic) NSObject<APMetricNotificationRegister, APMetricReceiving> *notificationRegistrar;

@end
```