### PR TITLE
fix: conforming to a protocol does not imply in conforming to NSObject

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -181,7 +181,7 @@ func getPropertyType(attrs string) (typ string) {
 		if strings.HasPrefix(attr, "@\"") {
 			typ = strings.Trim(attr, "@\"")
 			if strings.HasPrefix(typ, "<") {
-				typ = "NSObject" + typ
+				typ = "id " + typ
 			}
 			typ += " *"
 		} else {
@@ -248,7 +248,7 @@ func getIVarType(ivType string) string {
 	if strings.HasPrefix(ivType, "@\"") && len(ivType) > 1 {
 		ivType = strings.Trim(ivType, "@\"")
 		if strings.HasPrefix(ivType, "<") {
-			ivType = "NSObject" + ivType
+			ivType = "id " + ivType
 		}
 		return ivType + " *"
 	}


### PR DESCRIPTION
Objects that conform to a protocol are not required to conform to `NSObject`. This patch makes go-macho use `id` instead of `NSObject` when referring to a type that conforms to some protocol.