### PR TITLE
fix: use of @optional directive in protocols and interfaces

### DIFF
--- a/types/objc/category.go
+++ b/types/objc/category.go
@@ -62,6 +62,7 @@ func (c *Category) dump(verbose, addrs bool) string {
 	} else {
 		cat = fmt.Sprintf("@interface %s(%s)%s", className, c.Name, protos)
 	}
+	cat += "\n"
 
 	if len(c.ClassMethods) > 0 {
 		s := bytes.NewBufferString("/* class methods */\n")
@@ -80,14 +81,12 @@ func (c *Category) dump(verbose, addrs bool) string {
 			}
 		}
 		cMethods = s.String()
+		if cMethods != "" {
+			cMethods += "\n"
+		}
 	}
 	if len(c.InstanceMethods) > 0 {
-		var s *bytes.Buffer
-		if len(c.ClassMethods) > 0 {
-			s = bytes.NewBufferString("\n/* instance methods */\n")
-		} else {
-			s = bytes.NewBufferString("/* instance methods */\n")
-		}
+		s := bytes.NewBufferString("/* instance methods */\n")
 		for _, meth := range c.InstanceMethods {
 			if !addrs && strings.HasPrefix(meth.Name, ".cxx_") {
 				continue
@@ -103,13 +102,20 @@ func (c *Category) dump(verbose, addrs bool) string {
 			}
 		}
 		iMethods = s.String()
+		if iMethods != "" {
+			iMethods += "\n"
+		}
 	}
 
 	return fmt.Sprintf(
-		"%s\n%s%s@end\n",
+		"%s\n"+
+			"%s"+
+			"%s"+
+			"@end\n",
 		cat,
 		cMethods,
-		iMethods)
+		iMethods,
+	)
 }
 
 func (c *Category) String() string {


### PR DESCRIPTION
The `@optional` directive of Objective-C defines that all property and method definitions bellow it are optional. This only changes if a `@required` directive is placed bellow it. go-macho doesn't implement this properly and mistakenly declares required methods as optional.

Additionally, `@required` and `@optional` should only ever be used inside `@protocol` blocks. But go-macho also uses them in `@interface` blocks.

This patch fixes both issues.

As I have tweaked the formatting of generated code slightly, I also changed the formatting of categories to keep consistency.

Before:
```objc
@protocol UIActivityItemsConfigurationReading <NSObject>

@property (readonly, copy, nonatomic) NSArray *itemProvidersForActivityItemsConfiguration;
@optional
@property (readonly, copy, nonatomic) NSArray *applicationActivitiesForActivityItemsConfiguration;

/* instance methods */
- (id)itemProvidersForActivityItemsConfiguration;
@optional
/* instance methods */
- (id)activityItemsConfigurationMetadataForItemAtIndex:(long long)index key:(id)key;
- (id)activityItemsConfigurationMetadataForKey:(id)key;
- (id)activityItemsConfigurationPreviewForItemAtIndex:(long long)index intent:(id)intent suggestedSize:(struct CGSize { double x0; double x1; })size;
- (id)applicationActivitiesForActivityItemsConfiguration;
- (char)activityItemsConfigurationSupportsInteraction:(id)interaction;
@end
```

After:
```objc
@protocol UIActivityItemsConfigurationReading <NSObject>

@required

@property (readonly, copy, nonatomic) NSArray *itemProvidersForActivityItemsConfiguration;

/* required instance methods */
- (id)itemProvidersForActivityItemsConfiguration;

@optional

@property (readonly, copy, nonatomic) NSArray *applicationActivitiesForActivityItemsConfiguration;

/* optional instance methods */
- (id)activityItemsConfigurationMetadataForItemAtIndex:(long long)index key:(id)key;
- (id)activityItemsConfigurationMetadataForKey:(id)key;
- (id)activityItemsConfigurationPreviewForItemAtIndex:(long long)index intent:(id)intent suggestedSize:(struct CGSize { double x0; double x1; })size;
- (id)applicationActivitiesForActivityItemsConfiguration;
- (char)activityItemsConfigurationSupportsInteraction:(id)interaction;

@end
```