### PR TITLE
fix: id followed by *

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -182,8 +182,9 @@ func getPropertyType(attrs string) (typ string) {
 			typ = strings.Trim(attr, "@\"")
 			if strings.HasPrefix(typ, "<") {
 				typ = "id " + strings.ReplaceAll(typ, "><", ", ")
+			} else {
+				typ += " *"
 			}
-			typ += " *"
 		} else {
 			typ = decodeType(attr) + " "
 		}
@@ -249,7 +250,7 @@ func getIVarType(ivType string) string {
 	if strings.HasPrefix(ivType, "@\"") && len(ivType) > 1 {
 		ivType = strings.Trim(ivType, "@\"")
 		if strings.HasPrefix(ivType, "<") {
-			ivType = "id " + strings.ReplaceAll(ivType, "><", ", ")
+			return "id " + strings.ReplaceAll(ivType, "><", ", ")
 		}
 		return ivType + " *"
 	}

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -181,7 +181,7 @@ func getPropertyType(attrs string) (typ string) {
 		if strings.HasPrefix(attr, "@\"") {
 			typ = strings.Trim(attr, "@\"")
 			if strings.HasPrefix(typ, "<") {
-				typ = "id " + strings.ReplaceAll(typ, "><", ", ")
+				typ = "id " + strings.ReplaceAll(typ, "><", ", ") + " "
 			} else {
 				typ += " *"
 			}
@@ -250,7 +250,7 @@ func getIVarType(ivType string) string {
 	if strings.HasPrefix(ivType, "@\"") && len(ivType) > 1 {
 		ivType = strings.Trim(ivType, "@\"")
 		if strings.HasPrefix(ivType, "<") {
-			return "id " + strings.ReplaceAll(ivType, "><", ", ")
+			return "id " + strings.ReplaceAll(ivType, "><", ", ") + " "
 		}
 		return ivType + " *"
 	}


### PR DESCRIPTION
`id` should not be followed by `*`. This should've been addressed in the `NSObject` to `id` PR.

Before:
```objc
@interface SORequestQueueItem : NSObject <SOQueueItem>

@property (readonly, nonatomic) id <SOServiceProtocol> *service;
```

After:
```objc
@interface SORequestQueueItem : NSObject <SOQueueItem>

@property (readonly, nonatomic) id <SOServiceProtocol> service;
```