### PR TITLE
fix: review obj-c type encoding

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -9,58 +9,58 @@ import (
 // ref - https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
 
 var typeEncoding = map[string]string{
-	"@": "id",
-	"#": "Class",
-	":": "SEL",
-	"c": "char",
-	"C": "unsigned char",
-	"s": "short",
-	"S": "unsigned short",
-	"i": "int",
-	"I": "unsigned int",
-	"l": "long",
-	"L": "unsigned long",
-	"q": "long long",
-	"Q": "unsigned long long",
-	"t": "int128",
-	"T": "unsigned int128",
-	"f": "float",
-	"d": "double",
-	"D": "long double",
-	"b": "bit field",
-	"B": "BOOL",
-	"v": "void",
-	"z": "size_t",
-	"Z": "int32",
-	"w": "wchar_t",
-	"?": "undefined",
-	"^": "*",
-	"*": "char *",
-	"%": "NXAtom",
-	// "[":  "", // _C_ARY_B
-	// "]":  "", // _C_ARY_E
-	// "(":  "", // _C_UNION_B
-	// ")":  "", // _C_UNION_E
-	// "{":  "", // _C_STRUCT_B
-	// "}":  "", // _C_STRUCT_E
-	"!":  "vector",
-	"Vv": "void",
-	"^?": "void *",         // void *
-	"@?": "id /* block */", // block type
-	// "@?": "void (^)(void)", // block type
+	"":   "",                      // Nothing
+	"!":  "vector",                // TODO: review
+	"#":  "Class",                 // Objective-C Class
+	"%":  "NXAtom",                // TODO: review
+	"*":  "char *",                // C String
+	":":  "SEL",                   // Objective-C Selector
+	"?":  "void * /* unknown */",  // Unknown (likely a C Function and unlikely an Objective-C Block)
+	"@":  "id",                    // Objective-C Pointer
+	"@?": "id /* block */",        // Objective-C Block Pointer
+	"B":  "_Bool",                 // C Boolean
+	"C":  "unsigned char",         // Unsigned C Character
+	"D":  "long double",           // Extended-Precision C Floating-Point
+	"I":  "unsigned int",          // Unsigned C Integer
+	"L":  "unsigned long",         // Unsigned C Long Integer
+	"Q":  "unsigned long long",    // Unsigned C Long-Long Integer
+	"S":  "unsigned short",        // Unsigned C Short Integer
+	"T":  "unsigned __int128",     // Unsigned C 128-bit Integer
+	"Z":  "int32",                 // MAYBE
+	"^":  "*",                     // C Pointer
+	"^?": "void * /* function */", // C Function Pointer
+	"b":  ":",                     // C Bit Field
+	"c":  "char",                  // Signed C Character or Objective-C Boolean
+	"d":  "double",                // Double-Precision C Floating-Point
+	"f":  "float",                 // Single-Precision C Floating-Point
+	"i":  "int",                   // Signed C Integer
+	"l":  "long",                  // Signed C Long Integer
+	"q":  "long long",             // Signed C Long-Long Integer
+	"s":  "short",                 // Signed C Short Integer
+	"t":  "__int128",              // Signed C 128-bit Integer
+	"w":  "wchar_t",               // TODO: review
+	"v":  "void",                  // C Void
+	"z":  "size_t",                // TODO: review
+	// "(": "", // C Union Begin
+	// ")": "", // C Union End
+	// "[": "", // C Array Begin
+	// "]": "", // C Array End
+	// "{": "", // C Struct Begin
+	// "}": "", // C Struct End
 }
+
 var typeSpecifiers = map[string]string{
+	"!": "vector",       // TODO: review
+	"+": "gnu register", // TODO: review
 	"A": "_Atomic",
-	"j": "_Complex",
-	"!": "vector",
-	"r": "const",
-	"n": "in",
 	"N": "inout",
+	"O": "bycopy",
+	"R": "byref",
+	"V": "oneway",
+	"j": "_Complex",
+	"n": "in",
 	"o": "out",
-	"O": "by copy",
-	"R": "by ref",
-	"V": "one way",
-	"+": "gnu register",
+	"r": "const",
 }
 
 const (
@@ -269,34 +269,12 @@ func getReturnType(types string) string {
 func decodeType(encType string) string {
 	var s string
 
-	if len(encType) == 0 {
-		return ""
+	if typ, ok := typeEncoding[encType]; ok {
+		return typ
 	}
 
 	if strings.HasPrefix(encType, "^") {
 		return decodeType(encType[1:]) + " *" // pointer
-	}
-
-	if strings.HasPrefix(encType, "@?") {
-		if len(encType) > 2 { // TODO: remove this??
-			pointerType := decodeType(encType[2:])
-			return "id  ^" + pointerType
-		} else {
-			return "id /* block */"
-		}
-	}
-
-	if strings.HasPrefix(encType, "^?") {
-		if len(encType) > 2 {
-			pointerType := decodeType(encType[2:])
-			return "void * " + pointerType
-		} else {
-			return "void *"
-		}
-	}
-
-	if typ, ok := typeEncoding[encType]; ok {
-		return typ
 	}
 
 	if spec, ok := typeSpecifiers[string(encType[0])]; ok {

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -51,7 +51,7 @@ var typeEncoding = map[string]string{
 }
 
 var typeSpecifiers = map[string]string{
-	"+": "gnu register", // TODO: review
+	"+": "/* gnu register */", // TODO: review
 	"A": "_Atomic",
 	"N": "inout",
 	"O": "bycopy",

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -61,6 +61,7 @@ var typeSpecifiers = map[string]string{
 	"n": "in",
 	"o": "out",
 	"r": "const",
+	"|": "/* gc invisible */", // TODO: review
 }
 
 const (


### PR DESCRIPTION
Changes to types map:
- set `B` to `_Bool`, because `@encode(_Bool) == "B" && @encode(BOOL) == "c"`
- set `t` to `__int128`, because `int128` is undeclared identifier
- set `T` to `unsigned __int128`, because `int128` is undeclared identifier
- set `?` to `void * /* unknown */`, because `undefined` is undeclared identifier
- set `^?` to `void * /* function */`, because `@encode(typeof(&main)) == "^?"` and to distinguish from `^v`
- unset `Vv`, because `@encode(oneway void) == "Vv"`

Changes to modifiers map:
- set `O` to `bycopy`, because `by` and `copy` are undeclared identifiers
- set `R` to `byref`, because `by` and `ref` are undeclared identifiers
- set `V` to `oneway`, because `one` and `way` are undeclared identifiers

Changes to decoding function:
- check types map before checking if type is pointer, this handles `""`, `"^?"`, and `"@?"`
- remove special handling for `"^?"` and `"@?"`, functions and blocks and never strongly typed

To be reviewed later:
- `"z": "size_t"`, seems invalid
- `"w": "wchar_t"`, seems invalid
- `"%": "NXAtom"`, seems invalid
- `"!": "vector"`, seems invalid and is set on both types and modifiers map
- see `/usr/include/i386/_types.h`:
  - `"c": "char"`, whether char is signed or unsigned is implementation-specific
  - integer types, size of these types are implementation-specific
