### PR TITLE
fix: type encoding for Objective-C

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -38,16 +38,16 @@ var typeEncoding = map[string]string{
 	"C":  "unsigned char",             // Unsigned C Character
 	"D":  "long double",               // Extended-Precision C Floating-Point (64 bits on ARM, 80 bits on Intel, and 128 bits on PowerPC)
 	"I":  "unsigned int",              // Unsigned C Integer
-	"L":  "unsigned int32_t",          // Unsigned C Long Integer (fixed at 32 bits)
+	"L":  "unsigned int32_t",          // Unsigned C Long Integer (fixed to 32 bits)
 	"Q":  "unsigned long long",        // Unsigned C Long-Long Integer
 	"S":  "unsigned short",            // Unsigned C Short Integer
-	"T":  "unsigned __int128",         // Unsigned C 128-bit Integer (fixed size)
+	"T":  "unsigned __int128",         // Unsigned C 128-bit Integer
 	"^?": "void * /* function */",     // C Function Pointer
 	"c":  "signed char",               // Signed C Character (fixed signedness) or Objective-C Boolean (on Intel)
 	"d":  "double",                    // Double-Precision C Floating-Point
 	"f":  "float",                     // Single-Precision C Floating-Point
 	"i":  "int",                       // Signed C Integer
-	"l":  "int32_t",                   // Signed C Long Integer (fixed at 32 bits)
+	"l":  "int32_t",                   // Signed C Long Integer (fixed to 32 bits)
 	"q":  "long long",                 // Signed C Long-Long Integer
 	"s":  "short",                     // Signed C Short Integer
 	"t":  "__int128",                  // Signed C 128-bit Integer

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -7,18 +7,20 @@ import (
 )
 
 // References:
-// 01. https://developer.apple.com/documentation/objectivec/bool#discussion
-// 02. https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly
-// 03. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1
-// 04. https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html#//apple_ref/doc/uid/TP40001064-CH207-SW1
-// 05. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
-// 06. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
-// 07. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
-// 08. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
-// 09. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-838/runtime/hashtable2.h#L251-L294
-// 10. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
-// 11. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
-// 12. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
+// 01. https://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors
+// 02. https://developer.apple.com/documentation/objectivec/bool#discussion
+// 03. https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly
+// 04. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1
+// 05. https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html#//apple_ref/doc/uid/TP40001064-CH207-SW1
+// 06. https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
+// 07. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
+// 08. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
+// 09. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
+// 10. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
+// 11. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-838/runtime/hashtable2.h#L251-L294
+// 12. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
+// 13. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
+// 14. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
 
 var typeEncoding = map[string]string{
 	"":   "",                          // Nothing

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -7,14 +7,18 @@ import (
 )
 
 // References:
-// 1. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
-// 2. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
-// 3. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
-// 4. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
-// 5. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
-// 6. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
-// 7. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
-// 8. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
+// 01. https://developer.apple.com/documentation/objectivec/bool#discussion
+// 02. https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly
+// 03. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1
+// 04. https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html#//apple_ref/doc/uid/TP40001064-CH207-SW1
+// 05. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
+// 06. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
+// 07. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
+// 08. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
+// 09. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-838/runtime/hashtable2.h#L251-L294
+// 10. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
+// 11. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
+// 12. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
 
 var typeEncoding = map[string]string{
 	"":   "",                          // Nothing

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -38,9 +38,7 @@ var typeEncoding = map[string]string{
 	"Q":  "unsigned long long",        // Unsigned C Long-Long Integer
 	"S":  "unsigned short",            // Unsigned C Short Integer
 	"T":  "unsigned __int128",         // Unsigned C 128-bit Integer (fixed size)
-	"^":  "/* pointer */",             // C Pointer
 	"^?": "void * /* function */",     // C Function Pointer
-	"b":  "/* bit field */",           // C Bit Field
 	"c":  "signed char",               // Signed C Character (fixed signedness) or Objective-C Boolean (on Intel)
 	"d":  "double",                    // Double-Precision C Floating-Point
 	"f":  "float",                     // Single-Precision C Floating-Point
@@ -51,6 +49,8 @@ var typeEncoding = map[string]string{
 	"t":  "__int128",                  // Signed C 128-bit Integer
 	"v":  "void",                      // C Void
 	// "!": "", // GNU Vector (LLVM Vector is unrepresented)
+	// "^": "", // C Pointer
+	// "b": "", // C Bit Field
 	// "(": "", // C Union Begin
 	// ")": "", // C Union End
 	// "[": "", // C Array Begin

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -6,42 +6,47 @@ import (
 	"unicode"
 )
 
-// ref - https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+// References:
+// 1. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+// 2. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
+// 3. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
+// 4. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
+// 5. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
+// 6. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
+// 7. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
+// 8. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
 
 var typeEncoding = map[string]string{
-	"":   "",                      // Nothing
-	"!":  "/* vector */",          // TODO: review
-	"#":  "Class",                 // Objective-C Class
-	"%":  "const char *",          // TODO: review
-	"*":  "char *",                // C String
-	":":  "SEL",                   // Objective-C Selector
-	"?":  "void * /* unknown */",  // Unknown (likely a C Function and unlikely an Objective-C Block)
-	"@":  "id",                    // Objective-C Pointer
-	"@?": "id /* block */",        // Objective-C Block Pointer
-	"B":  "_Bool",                 // C Boolean
-	"C":  "unsigned char",         // Unsigned C Character
-	"D":  "long double",           // Extended-Precision C Floating-Point
-	"I":  "unsigned int",          // Unsigned C Integer
-	"L":  "unsigned long",         // Unsigned C Long Integer
-	"Q":  "unsigned long long",    // Unsigned C Long-Long Integer
-	"S":  "unsigned short",        // Unsigned C Short Integer
-	"T":  "unsigned __int128",     // Unsigned C 128-bit Integer
-	"^":  "*",                     // C Pointer
-	"^?": "void * /* function */", // C Function Pointer
-	"b":  ":",                     // C Bit Field
-	"c":  "char",                  // Signed C Character or Objective-C Boolean
-	"d":  "double",                // Double-Precision C Floating-Point
-	"f":  "float",                 // Single-Precision C Floating-Point
-	"i":  "int",                   // Signed C Integer
-	"l":  "long",                  // Signed C Long Integer
-	"q":  "long long",             // Signed C Long-Long Integer
-	"s":  "short",                 // Signed C Short Integer
-	"t":  "__int128",              // Signed C 128-bit Integer
-	"v":  "void",                  // C Void
-	// "%": "NXAtom", // TODO: review
-	// "Z": "int32", // TODO: review
-	// "w": "wchar_t", // TODO: review
-	// "z": "size_t", // TODO: review
+	"":   "",                          // Nothing
+	" ":  "_Float16",                  // Half-Precision C Floating-Point (LLVM only)
+	"#":  "Class",                     // Objective-C Class
+	"%":  "const char * /* NXAtom */", // Objective-C NXAtom (legacy Objective-C runtime only)
+	"*":  "char *",                    // C String
+	":":  "SEL",                       // Objective-C Selector
+	"?":  "void * /* unknown */",      // Unknown (likely a C Function and unlikely an Objective-C Block)
+	"@":  "id",                        // Objective-C Pointer
+	"@?": "id /* block */",            // Objective-C Block Pointer
+	"B":  "_Bool",                     // C Boolean or Objective-C Boolean (on ARM and PowerPC)
+	"C":  "unsigned char",             // Unsigned C Character
+	"D":  "long double",               // Extended-Precision C Floating-Point (64 bits on ARM, 80 bits on Intel, and 128 bits on PowerPC)
+	"I":  "unsigned int",              // Unsigned C Integer
+	"L":  "unsigned int32_t",          // Unsigned C Long Integer (fixed at 32 bits)
+	"Q":  "unsigned long long",        // Unsigned C Long-Long Integer
+	"S":  "unsigned short",            // Unsigned C Short Integer
+	"T":  "unsigned __int128",         // Unsigned C 128-bit Integer (fixed size)
+	"^":  "/* pointer */",             // C Pointer
+	"^?": "void * /* function */",     // C Function Pointer
+	"b":  "/* bit field */",           // C Bit Field
+	"c":  "signed char",               // Signed C Character (fixed signedness) or Objective-C Boolean (on Intel)
+	"d":  "double",                    // Double-Precision C Floating-Point
+	"f":  "float",                     // Single-Precision C Floating-Point
+	"i":  "int",                       // Signed C Integer
+	"l":  "int32_t",                   // Signed C Long Integer (fixed at 32 bits)
+	"q":  "long long",                 // Signed C Long-Long Integer
+	"s":  "short",                     // Signed C Short Integer
+	"t":  "__int128",                  // Signed C 128-bit Integer
+	"v":  "void",                      // C Void
+	// "!": "", // GNU Vector (LLVM Vector is unrepresented)
 	// "(": "", // C Union Begin
 	// ")": "", // C Union End
 	// "[": "", // C Array Begin

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -7,20 +7,22 @@ import (
 )
 
 // References:
-// 01. https://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors
-// 02. https://developer.apple.com/documentation/objectivec/bool#discussion
-// 03. https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly
-// 04. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1
-// 05. https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html#//apple_ref/doc/uid/TP40001064-CH207-SW1
-// 06. https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
-// 07. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
-// 08. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
-// 09. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
-// 10. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
-// 11. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-838/runtime/hashtable2.h#L251-L294
-// 12. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
-// 13. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
-// 14. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
+// 01. https://clang.llvm.org/docs/LanguageExtensions.html#half-precision-floating-point
+// 02. https://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors
+// 03. https://developer.apple.com/documentation/objectivec/bool#discussion
+// 04. https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly
+// 05. https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1
+// 06. https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/64bitPorting/transition/transition.html#//apple_ref/doc/uid/TP40001064-CH207-SW1
+// 07. https://gcc.gnu.org/onlinedocs/gcc/Half-Precision.html
+// 08. https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
+// 09. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclBase.h#L173-L200
+// 10. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/include/clang/AST/DeclObjC.h#L698-L727
+// 11. https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5452-L5518
+// 12. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-906/runtime/runtime.h#L1856-L1900
+// 13. https://github.com/apple-oss-distributions/objc4/blob/rel/objc4-838/runtime/hashtable2.h#L251-L294
+// 14. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/doc/objc.texi
+// 15. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc
+// 16. https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libobjc/objc/runtime.h#L83-L139
 
 var typeEncoding = map[string]string{
 	"":   "",                          // Nothing


### PR DESCRIPTION
I did some research and reviewed all types encodings and made some changes. Also added a new list of references and various comments clarifying types.

About `!`, I've found out that it represents non-standard vector types ([GNU](https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html) and [LLVM](https://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors)). `gcc` is able encode these types in Objective-C but `clang` fails with _Encoding of 'v4si' (vector of 4 'int' values) type is incomplete because 'v4si' component has unknown encoding_. I'll be implementing the encoding for these types latter this week.

I just learned that C has a half-precision floating-point types: `__bf16`, `__fp16`, `_Float16`. The latter is the portable version and `clang` encodes it using the space character. It's clear in the compiler source code that this is a mistake, but the fact is that it encodes that type this way: https://github.com/apple-oss-distributions/clang/blob/rel/clang-800/src/tools/clang/lib/AST/ASTContext.cpp#L5482-L5484. `gcc` throws an internal compiler error while trying to encode this type because it reaches `gcc_unreachable`: https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/gcc/objc/objc-encoding.cc#L673.

Regarding `NXAtom`, it was just removed from the Apple SDKs a few months ago. You used to be able to access with `#include <objc/hashtable.h>`. It turns out that type was created in the NeXTSTEP era so you never had duplicated strings in memory and could compare them using `==` instead of `strcmp`. The type was simply `const char *` and all magic happened in the `NXUniqueString` function.

Also, I discovered that `clang` and `gcc` encode some qualifiers very differently and sometimes in a conflict way. I don't think there is much to do about it other than stick to Apple's implementation.

| Type | GNU | LLVM |
| - | - | - |
| `typedef const int * cip_t;` | `^ri` | `^i` |
| `typedef int const * icp_t;` | `^ri` | `^i` |
| `typedef int * const ipc_t;` | `r^i` | `r^i` |
| `const int * cip;` | `^ri` | `r^i` |
| `int const * icp;` | `^ri` | `r^i` |
| `int * const ipc;` | `r^i` | `^i` |

Finally, just so we have it documented, `BOOL` is encoded differently in ARM and PowerPC vs AMD and Intel. This is important because the headers generated for Apple Silicon and Intel Macs differ and this hugely affects the idea of a generic XCFW.

| Type | ARM and PowerPC | AMD and Intel |
| - | - | - |
| `BOOL` | `B` | `c` |

Change Log:
- Commented `!`, `^`, and `b` because they require special handling
- Defines `_Float16` as ` ` (space character)
- Added comment to distinguish between `NSAtom` and `const char *`
- Replaced `long` with `int32_t` as `l` and `L` are always 32-bit integers and the size of `long` varies from architecture to architecture
- Added `signed` modifier to `char` because the signedness of `char` is implementation-specific and `c` is always a signed 8-bit integer
- Removed `w`, `z`, and `Z` because I found no evidence of their existence in `clang` or `gcc`