### PR TITLE
fix: struct fields with specifiers

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -492,17 +492,27 @@ func skipFirstType(typStr string) string {
 	typ := []byte(typStr)
 	for {
 		switch typ[i] {
+		case '+': /* gnu register */
+			fallthrough
+		case 'A': /* _Atomic */
+			fallthrough
+		case 'N': /* inout */
+			fallthrough
 		case 'O': /* bycopy */
+			fallthrough
+		case 'R': /* byref */
+			fallthrough
+		case 'V': /* oneway */
+			fallthrough
+		case 'j': /* _Complex */
 			fallthrough
 		case 'n': /* in */
 			fallthrough
 		case 'o': /* out */
 			fallthrough
-		case 'N': /* inout */
-			fallthrough
 		case 'r': /* const */
 			fallthrough
-		case 'V': /* oneway */
+		case '|': /* gc invisible */
 			fallthrough
 		case '^': /* pointers */
 			i++
@@ -573,17 +583,27 @@ func CutType(typStr string) (string, string, bool) {
 	typ := []byte(typStr)
 	for {
 		switch typ[i] {
+		case '+': /* gnu register */
+			fallthrough
+		case 'A': /* _Atomic */
+			fallthrough
+		case 'N': /* inout */
+			fallthrough
 		case 'O': /* bycopy */
+			fallthrough
+		case 'R': /* byref */
+			fallthrough
+		case 'V': /* oneway */
+			fallthrough
+		case 'j': /* _Complex */
 			fallthrough
 		case 'n': /* in */
 			fallthrough
 		case 'o': /* out */
 			fallthrough
-		case 'N': /* inout */
-			fallthrough
 		case 'r': /* const */
 			fallthrough
-		case 'V': /* oneway */
+		case '|': /* gc invisible */
 			fallthrough
 		case '^': /* pointers */
 			i++

--- a/types/objc/type_encoding_test.go
+++ b/types/objc/type_encoding_test.go
@@ -14,9 +14,9 @@ func Test_decodeType(t *testing.T) {
 		{
 			name: "Test all",
 			args: args{
-				encType: "^{OutterStruct=(InnerUnion=q{InnerStruct=ii})b1b2b10b1q[2^v]^![4,8c]}",
+				encType: "^{OutterStruct=(InnerUnion=q{InnerStruct=ii})b1b2b10b1q[2^v]^![4,8c]AQ}",
 			},
-			want: "struct OutterStruct { union InnerUnion { long long x0; struct InnerStruct { int x0; int x1; } x1; } x0; unsigned int x1:1; unsigned int x2:2; unsigned int x3:10; unsigned int x4:1; long long x5; void *x6[2]; signed char *x7 __attribute__((aligned(8), vector_size(4))); } *",
+			want: "struct OutterStruct { union InnerUnion { long long x0; struct InnerStruct { int x0; int x1; } x1; } x0; unsigned int x1:1; unsigned int x2:2; unsigned int x3:10; unsigned int x4:1; long long x5; void *x6[2]; signed char *x7 __attribute__((aligned(8), vector_size(4))); _Atomic unsigned long long x8; } *",
 		},
 		{
 			name: "Test array",
@@ -66,6 +66,13 @@ func Test_decodeType(t *testing.T) {
 				encType: "^{?}",
 			},
 			want: "void * /* struct */",
+		},
+		{
+			name: "Test struct 4",
+			args: args{
+				encType: "{__CFRuntimeBase=QAQ}",
+			},
+			want: "struct __CFRuntimeBase { unsigned long long x0; _Atomic unsigned long long x1; }",
 		},
 		{
 			name: "Test union 0",


### PR DESCRIPTION
Add missing type specifiers to fix struct and union parsing.

Before:
```objc
@class __cached_isReady, __isCancelled, __isCancelledObserverCount, __isExecutingObserverCount, __isFinishedObserverCount, __isReadyObserverCount, __propertyQoS, __state;
@protocol OS_voucher;

@interface NSOperation : NSObject {
    /* instance variables */
    struct { NSOperation *__prevOp; NSOperation *__nextOp; NSOperation *__nextPriOp; NSOperationQueue *__queue; NSMutableArray *__dependencies; NSHashTable *__down_dependencies; long long __unfinished_deps; id /* block */ __completion; void *__obsInfo; void *__implicitObsInfo; double __thread_prio; char *__nameBuffer; NSObject<OS_voucher> *_voucher; id /* block */ __schedule; struct _opaque_pthread_mutex_t { long long __sig; signed char __opaque[56]; } __wait_mutex; struct _opaque_pthread_cond_t { long long __sig; signed char __opaque[40]; } __wait_cond; struct os_unfair_lock_s { unsigned int _os_unfair_lock_opaque; } __lock; signed char _shouldRemoveDependenciesAfterFinish; _Atomic  __state; unsigned char x19; signed char __prio; _Atomic  __cached_isReady; signed char x22; _Atomic  __isCancelled; signed char x24; _Atomic  __propertyQoS; unsigned char x26; _Atomic  __isExecutingObserverCount; unsigned char x28; _Atomic  __isFinishedObserverCount; unsigned char x30; _Atomic  __isReadyObserverCount; unsigned char x32; _Atomic  __isCancelledObserverCount; unsigned char x34; } _iop;
}
```

After:
```objc
@protocol OS_voucher;

@interface NSOperation : NSObject {
    /* instance variables */
    struct { NSOperation *__prevOp; NSOperation *__nextOp; NSOperation *__nextPriOp; NSOperationQueue *__queue; NSMutableArray *__dependencies; NSHashTable *__down_dependencies; long long __unfinished_deps; id /* block */ __completion; void *__obsInfo; void *__implicitObsInfo; double __thread_prio; char *__nameBuffer; NSObject<OS_voucher> *_voucher; id /* block */ __schedule; struct _opaque_pthread_mutex_t { long long __sig; signed char __opaque[56]; } __wait_mutex; struct _opaque_pthread_cond_t { long long __sig; signed char __opaque[40]; } __wait_cond; struct os_unfair_lock_s { unsigned int _os_unfair_lock_opaque; } __lock; signed char _shouldRemoveDependenciesAfterFinish; _Atomic unsigned char __state; signed char __prio; _Atomic signed char __cached_isReady; _Atomic signed char __isCancelled; _Atomic unsigned char __propertyQoS; _Atomic unsigned char __isExecutingObserverCount; _Atomic unsigned char __isFinishedObserverCount; _Atomic unsigned char __isReadyObserverCount; _Atomic unsigned char __isCancelledObserverCount; } _iop;
}
```

Fixes: https://github.com/blacktop/ipsw/pull/481#issuecomment-2143629457