### PR TITLE
fix: decoding struct and union fields with ambiguous types

### DIFF
--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -449,7 +449,7 @@ func decodeStructOrUnion(typ, kind string) string {
 		// Although technically possible, binaries produced by clang never have a
 		// mix of named and unnamed fields in the same struct. This assumption is
 		// necessary to disambiguate {"x0"@"x1"c}.
-		if fieldName != "" && strings.HasSuffix(field, `"`) && !strings.HasPrefix(rest, `"`) {
+		if fieldName != "" && rest != "" && strings.HasSuffix(field, `"`) && !strings.HasPrefix(rest, `"`) {
 			penultQuoteIdx := strings.LastIndex(strings.TrimRight(field, `"`), `"`)
 			rest = field[penultQuoteIdx:] + rest
 			field = field[:penultQuoteIdx]

--- a/types/objc/type_encoding.go
+++ b/types/objc/type_encoding.go
@@ -446,6 +446,15 @@ func decodeStructOrUnion(typ, kind string) string {
 	field, rest, ok := CutType(rest)
 
 	for ok {
+		// Although technically possible, binaries produced by clang never have a
+		// mix of named and unnamed fields in the same struct. This assumption is
+		// necessary to disambiguate {"x0"@"x1"c}.
+		if fieldName != "" && strings.HasSuffix(field, `"`) && !strings.HasPrefix(rest, `"`) {
+			penultQuoteIdx := strings.LastIndex(strings.TrimRight(field, `"`), `"`)
+			rest = field[penultQuoteIdx:] + rest
+			field = field[:penultQuoteIdx]
+		}
+
 		if fieldName == "" {
 			fieldName = fmt.Sprintf("x%d", idx)
 		}

--- a/types/objc/type_encoding_test.go
+++ b/types/objc/type_encoding_test.go
@@ -103,6 +103,13 @@ func Test_decodeType(t *testing.T) {
 			want: "void * /* union */",
 		},
 		{
+			name: "Test union 3",
+			args: args{
+				encType: "(?=\"xpc\"@\"NSObject<OS_xpc_object>\"\"remote\"@\"OS_xpc_remote_connection\")",
+			},
+			want: "union { NSObject<OS_xpc_object> *xpc; OS_xpc_remote_connection *remote; }",
+		},
+		{
 			name: "Test block",
 			args: args{
 				encType: "@?",

--- a/types/objc/type_encoding_test.go
+++ b/types/objc/type_encoding_test.go
@@ -75,6 +75,13 @@ func Test_decodeType(t *testing.T) {
 			want: "struct __CFRuntimeBase { unsigned long long x0; _Atomic unsigned long long x1; }",
 		},
 		{
+			name: "Test struct 4",
+			args: args{
+				encType: "{__cfobservers_t=\"slot\"@\"next\"^{__cfobservers_t}}",
+			},
+			want: "struct __cfobservers_t { id slot; struct __cfobservers_t *next; }",
+		},
+		{
 			name: "Test union 0",
 			args: args{
 				encType: "(?=i)",


### PR DESCRIPTION
The `@"` sequence is ambiguous when used inside structs and unions. This patch makes go-macho correctly decode these types based on the behaviour of clang.

| Encoded Type | Decoded Type |
| - | - |
| `{S="Id"@"NSString"^{S}}` | `struct S { id Id; struct S *NSString; }`
| `{S="Id"@"NSString""NSString"^{S}}` | `struct S { NSString *Id; struct S *NSString; }`
| `{?=@"NSString"^{S}}` | `struct { NSString *; struct S *; }`

Before:
```objc
@class next;

@interface __CFPrefsWeakObservers : NSObject <NSMutableCopying> {
    /* instance variables */
    struct __cfobservers_t { next *slot; struct __cfobservers_t *x1; } values;
```

After:
```objc
@interface __CFPrefsWeakObservers : NSObject <NSMutableCopying> {
    /* instance variables */
    struct __cfobservers_t { id slot; struct __cfobservers_t *next; } values;
```