### PR TITLE
Fix ReadSleb128

### DIFF
--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -85,11 +85,11 @@ func ReadSleb128(r *bytes.Reader) (int64, error) {
 
 		// If high order bit is 1.
 		if (b & 0x80) == 0 {
-			break
-		}
+			if (shift < 64) && ((b & 0x40) > 0) {
+				result |= -(1 << shift)
+			}
 
-		if (shift < 64) && ((b & 0x40) > 0) {
-			result |= -(1 << shift)
+			break
 		}
 	}
 


### PR DESCRIPTION
Addends of Mach-O Binding Info were not matching the values from `dyld_info -symbolic_fixups`. This problem was caused by a bug in the implementation of `ReadSleb128`. Fixing this bug addressed the problem with the addends.

#### `dyld_info -symbolic_fixups`

```console
           +0x0000      bind pointer   IOKit/_IOServiceMatching+54
           +0x0008      bind pointer   CoreFoundation/_CFDictionaryCreateMutable+5067
           +0x0010      bind pointer   CoreFoundation/_CFStringCreateWithCString+4672
           +0x0018      bind pointer   CoreFoundation/_CFDictionarySetValue+1754
           +0x0020      bind pointer   CoreFoundation/_CFRelease+83
           +0x0028      bind pointer   IOKit/_IOServiceGetMatchingServices+600
           +0x0030      bind pointer   IOKit/_IORegistryEntryGetParentEntry+2510
           +0x0038      bind pointer   IOKit/_IORegistryEntryCreateCFProperty+4336
           +0x0040      bind pointer   CoreFoundation/_CFDataGetBytes+1712
           +0x0048      bind pointer   IOKit/_IOObjectRelease+5997
           +0x0050      bind pointer   IOKit/_IOIteratorNext+7073
           +0x0058      bind pointer   IOKit/_IOServiceGetMatchingService+1012
           +0x0060      bind pointer   CoreFoundation/_CFStringGetLength+2421
           +0x0068      bind pointer   CoreFoundation/_CFStringGetMaximumSizeForEncoding+4862
           +0x0070      bind pointer   libSystem.B.dylib/_malloc+3686
           +0x0078      bind pointer   CoreFoundation/_CFStringGetCString+7151
           +0x0080      bind pointer   libSystem.B.dylib/_free+6579
           +0x0088      bind pointer   libSystem.B.dylib/_statfs+804
           +0x0090      bind pointer   DiskArbitration/_DASessionCreate+6356
           +0x0098      bind pointer   DiskArbitration/_DADiskCreateFromBSDName+5048
           +0x00A0      bind pointer   DiskArbitration/_DADiskCopyDescription+7256
           +0x00A8      bind pointer   CoreFoundation/_CFDictionaryGetValue+3883
           +0x00B0      bind pointer   CoreFoundation/_CFUUIDCreateString+6692
           +0x00B8      bind pointer   IOKit/_IORegistryEntryFromPath+2185
           +0x00C0      bind pointer   CoreFoundation/_CFDataGetLength+6403
           +0x00C8      bind pointer   CoreFoundation/_CFDataGetBytePtr+819
           +0x00D0      bind pointer   libSystem.B.dylib/_sysctlbyname+1751
           +0x00D8      bind pointer   libSystem.B.dylib/_arc4random+7358
           +0x00E0      bind pointer   libSystem.B.dylib/_pthread_once+1555
```

#### `go-macho` Before

```console
__DATA  __data            0x32d710  BIND  pointer      7073 IOKit                    	_IOIteratorNext
__DATA  __data            0x32d708  BIND  pointer       -19 IOKit                    	_IOObjectRelease
__DATA  __data            0x32d6f8  BIND  pointer       -16 IOKit                    	_IORegistryEntryCreateCFProperty
__DATA  __data            0x32d778  BIND  pointer      2185 IOKit                    	_IORegistryEntryFromPath
__DATA  __data            0x32d6f0  BIND  pointer       -50 IOKit                    	_IORegistryEntryGetParentEntry
__DATA  __data            0x32d718  BIND  pointer       -12 IOKit                    	_IOServiceGetMatchingService
__DATA  __data            0x32d6e8  BIND  pointer       -40 IOKit                    	_IOServiceGetMatchingServices
__DATA  __data            0x32d6c0  BIND  pointer        54 IOKit                    	_IOServiceMatching
__DATA  __data            0x32d760  BIND  pointer       -40 DiskArbitration          	_DADiskCopyDescription
__DATA  __data            0x32d758  BIND  pointer      5048 DiskArbitration          	_DADiskCreateFromBSDName
__DATA  __data            0x32d750  BIND  pointer       -44 DiskArbitration          	_DASessionCreate
__DATA  __data            0x32d798  BIND  pointer      7358 libSystem.B.dylib        	_arc4random
__DATA  __data            0x32d740  BIND  pointer      6579 libSystem.B.dylib        	_free
__DATA  __data            0x32d730  BIND  pointer       -26 libSystem.B.dylib        	_malloc
__DATA  __data            0x32d7a0  BIND  pointer      1555 libSystem.B.dylib        	_pthread_once
__DATA  __data            0x32d748  BIND  pointer       804 libSystem.B.dylib        	_statfs
__DATA  __data            0x32d790  BIND  pointer       -41 libSystem.B.dylib        	_sysctlbyname
__DATA  __data            0x32d788  BIND  pointer       819 CoreFoundation           	_CFDataGetBytePtr
__DATA  __data            0x32d700  BIND  pointer      1712 CoreFoundation           	_CFDataGetBytes
__DATA  __data            0x32d780  BIND  pointer      6403 CoreFoundation           	_CFDataGetLength
__DATA  __data            0x32d6c8  BIND  pointer       -53 CoreFoundation           	_CFDictionaryCreateMutable
__DATA  __data            0x32d768  BIND  pointer      3883 CoreFoundation           	_CFDictionaryGetValue
__DATA  __data            0x32d6d8  BIND  pointer       -38 CoreFoundation           	_CFDictionarySetValue
__DATA  __data            0x32d6e0  BIND  pointer       -45 CoreFoundation           	_CFRelease
__DATA  __data            0x32d6d0  BIND  pointer       -64 CoreFoundation           	_CFStringCreateWithCString
__DATA  __data            0x32d738  BIND  pointer       -17 CoreFoundation           	_CFStringGetCString
__DATA  __data            0x32d720  BIND  pointer       -11 CoreFoundation           	_CFStringGetLength
__DATA  __data            0x32d728  BIND  pointer        -2 CoreFoundation           	_CFStringGetMaximumSizeForEncoding
__DATA  __data            0x32d770  BIND  pointer      6692 CoreFoundation           	_CFUUIDCreateString
```

#### `go-macho` After

```console
__DATA  __data            0x32d710  BIND  pointer      7073 IOKit                    	_IOIteratorNext
__DATA  __data            0x32d708  BIND  pointer      5997 IOKit                    	_IOObjectRelease
__DATA  __data            0x32d6f8  BIND  pointer      4336 IOKit                    	_IORegistryEntryCreateCFProperty
__DATA  __data            0x32d778  BIND  pointer      2185 IOKit                    	_IORegistryEntryFromPath
__DATA  __data            0x32d6f0  BIND  pointer      2510 IOKit                    	_IORegistryEntryGetParentEntry
__DATA  __data            0x32d718  BIND  pointer      1012 IOKit                    	_IOServiceGetMatchingService
__DATA  __data            0x32d6e8  BIND  pointer       600 IOKit                    	_IOServiceGetMatchingServices
__DATA  __data            0x32d6c0  BIND  pointer        54 IOKit                    	_IOServiceMatching
__DATA  __data            0x32d760  BIND  pointer      7256 DiskArbitration          	_DADiskCopyDescription
__DATA  __data            0x32d758  BIND  pointer      5048 DiskArbitration          	_DADiskCreateFromBSDName
__DATA  __data            0x32d750  BIND  pointer      6356 DiskArbitration          	_DASessionCreate
__DATA  __data            0x32d798  BIND  pointer      7358 libSystem.B.dylib        	_arc4random
__DATA  __data            0x32d740  BIND  pointer      6579 libSystem.B.dylib        	_free
__DATA  __data            0x32d730  BIND  pointer      3686 libSystem.B.dylib        	_malloc
__DATA  __data            0x32d7a0  BIND  pointer      1555 libSystem.B.dylib        	_pthread_once
__DATA  __data            0x32d748  BIND  pointer       804 libSystem.B.dylib        	_statfs
__DATA  __data            0x32d790  BIND  pointer      1751 libSystem.B.dylib        	_sysctlbyname
__DATA  __data            0x32d788  BIND  pointer       819 CoreFoundation           	_CFDataGetBytePtr
__DATA  __data            0x32d700  BIND  pointer      1712 CoreFoundation           	_CFDataGetBytes
__DATA  __data            0x32d780  BIND  pointer      6403 CoreFoundation           	_CFDataGetLength
__DATA  __data            0x32d6c8  BIND  pointer      5067 CoreFoundation           	_CFDictionaryCreateMutable
__DATA  __data            0x32d768  BIND  pointer      3883 CoreFoundation           	_CFDictionaryGetValue
__DATA  __data            0x32d6d8  BIND  pointer      1754 CoreFoundation           	_CFDictionarySetValue
__DATA  __data            0x32d6e0  BIND  pointer        83 CoreFoundation           	_CFRelease
__DATA  __data            0x32d6d0  BIND  pointer      4672 CoreFoundation           	_CFStringCreateWithCString
__DATA  __data            0x32d738  BIND  pointer      7151 CoreFoundation           	_CFStringGetCString
__DATA  __data            0x32d720  BIND  pointer      2421 CoreFoundation           	_CFStringGetLength
__DATA  __data            0x32d728  BIND  pointer      4862 CoreFoundation           	_CFStringGetMaximumSizeForEncoding
__DATA  __data            0x32d770  BIND  pointer      6692 CoreFoundation           	_CFUUIDCreateString
```