### PR TITLE
make OpenRaw return SectionReader

### DIFF
--- a/pkg/xar/xar.go
+++ b/pkg/xar/xar.go
@@ -515,12 +515,11 @@ func (f *File) Open() (rc io.ReadCloser, err error) {
 	return rc, err
 }
 
-// OpenRaw returns a ReadCloser that provides access to the file's
+// OpenRaw returns a SectionReader that provides access to the file's
 // raw content. The encoding of the raw content is specified in
 // the File's EncodingMimetype field.
-func (f *File) OpenRaw() (rc io.ReadCloser, err error) {
-	rc = ioutil.NopCloser(io.NewSectionReader(f.heap, f.offset, f.length))
-	return
+func (f *File) OpenRaw() *io.SectionReader {
+	return io.NewSectionReader(f.heap, f.offset, f.length)
 }
 
 // Verify that the compressed content of the File in the


### PR DESCRIPTION
This patch makes `OpenRaw` return `SectionReader` instead `ReadCloser` to allow random access to the underlying file.