### PR TITLE
Expose Additional Load Commands and Promote Function Cache to Public API

### DIFF
--- a/file.go
+++ b/file.go
@@ -2014,8 +2014,8 @@ func (f *File) FunctionStarts() *FunctionStarts {
 }
 
 func (f *File) GenerateFunctionStarts() ([]types.Function, error) {
-	if len(f.functions) > 0 {
-		return f.functions, nil
+	if len(f.Functions) > 0 {
+		return f.Functions, nil
 	}
 
 	if !f.isArm64e() {
@@ -2058,7 +2058,7 @@ func (f *File) GenerateFunctionStarts() ([]types.Function, error) {
 	}
 	funcs[len(funcs)-1].EndAddr = Align(text.Addr+text.Size, uint64(text.Align))
 
-	f.functions = funcs
+	f.Functions = funcs
 
 	return funcs, nil
 }
@@ -2066,8 +2066,8 @@ func (f *File) GenerateFunctionStarts() ([]types.Function, error) {
 // GetFunctions returns the function array, or nil if none exists.
 func (f *File) GetFunctions(data ...byte) []types.Function {
 
-	if len(f.functions) > 0 {
-		return f.functions
+	if len(f.Functions) > 0 {
+		return f.Functions
 	}
 
 	var funcs []types.Function
@@ -2127,7 +2127,7 @@ func (f *File) GetFunctions(data ...byte) []types.Function {
 	}
 
 	// cache parsed functions
-	f.functions = funcs
+	f.Functions = funcs
 
 	return funcs
 }

--- a/toc.go
+++ b/toc.go
@@ -14,7 +14,7 @@ type FileTOC struct {
 	ByteOrder binary.ByteOrder
 	Loads     loads
 	Sections  []*types.Section
-	functions []types.Function
+	Functions []types.Function
 }
 
 func (t *FileTOC) AddLoad(l Load) uint32 {


### PR DESCRIPTION
This PR expands the File and FileTOC structures to expose more Mach-O load commands and improves the visibility of function start data.

Public Fields on File:

- Dylibs []*LoadDylib
- DylibIDs []*IDDylib
- Dylinkers []*LoadDylinker
- DyldEnvironments []*DyldEnvironment
- SourceVersions []*SourceVersion
- LinkerOptions []*LinkerOption

File now populates the new slices during parsing of load commands like:

1. LC_LOAD_DYLIB, LC_ID_DYLIB
2. LC_LOAD_DYLINKER, LC_ID_DYLINKER
3. LC_SOURCE_VERSION
4. LC_DYLD_ENVIRONMENT
5. LC_LINKER_OPTION

Promoted the previously private functions []types.Function in FileTOC to Functions []types.Function.
