### PR TITLE
fix DyldChainedPtrArm64eAuthRebase24 fields offsets

### DIFF
--- a/pkg/fixupchains/types.go
+++ b/pkg/fixupchains/types.go
@@ -631,16 +631,16 @@ func (d DyldChainedPtrArm64eAuthRebase24) Raw() uint64 {
 	return d.Pointer
 }
 func (d DyldChainedPtrArm64eAuthRebase24) Target() uint64 {
-	return types.ExtractBits(uint64(d.Pointer), 0, 24) // target
+	return types.ExtractBits(uint64(d.Pointer), 0, 32) // target
 }
 func (d DyldChainedPtrArm64eAuthRebase24) Diversity() uint64 {
-	return types.ExtractBits(uint64(d.Pointer), 24, 16)
+	return types.ExtractBits(uint64(d.Pointer), 32, 16)
 }
 func (d DyldChainedPtrArm64eAuthRebase24) AddrDiv() uint64 {
-	return types.ExtractBits(uint64(d.Pointer), 40, 1)
+	return types.ExtractBits(uint64(d.Pointer), 48, 1)
 }
 func (d DyldChainedPtrArm64eAuthRebase24) Key() uint64 {
-	return types.ExtractBits(uint64(d.Pointer), 41, 2)
+	return types.ExtractBits(uint64(d.Pointer), 49, 2)
 }
 func (d DyldChainedPtrArm64eAuthRebase24) Next() uint64 {
 	return types.ExtractBits(uint64(d.Pointer), 51, 11) // 8-byte stide


### PR DESCRIPTION
I recently encountered mismatches with the output of the `ipsw macho info --fixups` command binaries from iOS 18.4+, where the parsed `key`, `diversity` and `addrDiv` fields seemed wrong. 
I tried to find a reference for parsing `diversity` from bit 24 as you do now, but only found it's from bit 32. 
For example, from the `dyld` headers:
https://github.com/apple-oss-distributions/dyld/blob/031f1c6ffb240a094f3f2f85f20dfd9e3f15b664/mach_o/ChainedFixups.cpp#L394
And from the LIEF headers:
https://github.com/lief-project/LIEF/blob/bb75e178cc16cfb14265d73e286b8afde0a8c1a5/include/LIEF/MachO/ChainedPointerAnalysis.hpp#L64

I compiled your `ipsw` tool with this fix and got the correct results this time.
