### PR TITLE
fix(objc): surface error on objc_class_t parse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blacktop/go-macho
 
-go 1.19
+go 1.20
 
 require github.com/blacktop/go-dwarf v1.0.14
 

--- a/objc.go
+++ b/objc.go
@@ -1450,13 +1450,12 @@ func (f *File) GetObjCClassReferences() (map[uint64]*objc.Class, error) {
 					} else {
 						if cls, err := f.GetObjCClass(ptr); err != nil {
 							if f.HasFixups() {
-								if bindName, err := f.GetBindName(ptr); err == nil {
+								if bindName, bindErr := f.GetBindName(ptr); bindErr == nil {
 									clsRefs[sec.Addr+uint64(idx*sizeOfInt64)] = &objc.Class{Name: strings.TrimPrefix(bindName, "_OBJC_CLASS_$_")}
 								} else {
-									return nil, fmt.Errorf("failed to read objc_class_t at classref ptr: %#x; %v", ptr, err)
+									return nil, fmt.Errorf("failed to read objc_class_t at classref ptr: %#x; %v", ptr, errors.Join(bindErr, err))
 								}
 							}
-							// TODO: don't swallow error here
 						} else {
 							clsRefs[sec.Addr+uint64(idx*sizeOfInt64)] = cls
 							f.PutObjC(ptr, cls)
@@ -1498,13 +1497,12 @@ func (f *File) GetObjCSuperReferences() (map[uint64]*objc.Class, error) {
 					} else {
 						if cls, err := f.GetObjCClass(ptr); err != nil {
 							if f.HasFixups() {
-								if bindName, err := f.GetBindName(ptr); err == nil {
+								if bindName, bindErr := f.GetBindName(ptr); bindErr == nil {
 									clsRefs[sec.Addr+uint64(idx*sizeOfInt64)] = &objc.Class{Name: strings.TrimPrefix(bindName, "_OBJC_CLASS_$_")}
 								} else {
-									return nil, fmt.Errorf("failed to read objc_class_t at superref ptr: %#x; %v", ptr, err)
+									return nil, fmt.Errorf("failed to read objc_class_t at superref ptr: %#x; %v", ptr, errors.Join(bindErr, err))
 								}
 							}
-							// TODO: don't swallow error here
 						} else {
 							clsRefs[sec.Addr+uint64(idx*sizeOfInt64)] = cls
 							f.PutObjC(ptr, cls)


### PR DESCRIPTION
If parsing fails, the fallback to bind name swallows the original error and replaces it with a red herring. This caught me in #76 and most likely also #70. This change will surface both errors.