### PR TITLE
Extraneous GenericPackShapeHeader in conformances

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1297,11 +1297,6 @@ func (f *File) readProtocolConformance(r io.ReadSeeker, addr uint64) (pcd *swift
 	}
 
 	if pcd.Flags.NumConditionalPackShapeDescriptors() > 0 {
-		var hdr swift.GenericPackShapeHeader
-		if err := binary.Read(r, f.ByteOrder, &hdr); err != nil {
-			return nil, fmt.Errorf("failed to read conditional pack shape header: %v", err)
-		}
-		_ = hdr // TODO: use this
 		pcd.ConditionalPackShapes = make([]swift.GenericPackShapeDescriptor, pcd.Flags.NumConditionalPackShapeDescriptors())
 		if err := binary.Read(r, f.ByteOrder, &pcd.ConditionalPackShapes); err != nil {
 			return nil, fmt.Errorf("failed to read conditional pack shape descriptors: %v", err)


### PR DESCRIPTION
There seems to be an extraneous `GenericPackShapeHeader` in the conformance parsing when compared to the [swift implementation](https://github.com/swiftlang/swift/blob/main/include/swift/ABI/Metadata.h#L2838). 

I think this is the cause of the "implausable witness count" issue in #83, because basically each subsequent offset is exactly one `GenericPackShapeHeader` off.

Test this by calling `GetSwiftProtocolConformances` on Foundation on `iPhone18,3_26.2_23C55_Restore.ipsw`:

```
package main
import (
	"fmt"
	"github.com/blacktop/ipsw/pkg/dyld"
)
func main() {
        f, _ := dyld.Open("/path/to/dyld_shared_cache_arm64e")
        img, _ := f.Image("Foundation")
        m, _ := img.GetMacho()
	if err != nil {
		panic(err) // On fail: "implausible witness count 1844581909"
	}
	fmt.Printf("OK: %d conformances\n", len(confs)) // "OK: 3633 conformances"
}
```

This seems like it might only come up when there's a [parameter pack](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0393-parameter-packs.md) and I don't think there was anything using that in the SDK until now.

Presumably there's something like the Regex system that uses Parameter Packs now and this is blowing up. SwiftUI could theoretically start using these as well to replace how they do `TupleView`.