### PR TITLE
swift: handle GenericRequirementKind.InvertedProtocols (Swift 6 ~Copyable/~Escapable)

### DIFF
--- a/swift.go
+++ b/swift.go
@@ -1255,6 +1255,8 @@ func (f *File) parseProtocol(r io.ReadSeeker, typ *swift.Type) (prot *swift.Prot
 				}
 			case swift.GRKindLayout:
 				prot.SignatureRequirements[idx].Kind = swift.GenericRequirementLayoutKind(req.TypeOrProtocolOrConformanceOrLayoutOff.RelOff).String()
+			case swift.GRKindInvertedProtocols:
+				prot.SignatureRequirements[idx].Kind = swift.InvertibleProtocolSet(uint32(req.TypeOrProtocolOrConformanceOrLayoutOff.RelOff) >> 16).String()
 			default:
 				return nil, fmt.Errorf("unknown signature requirement kind: %v", req.Flags.Kind())
 			}
@@ -1508,6 +1510,8 @@ func (f *File) readProtocolConformance(r io.ReadSeeker, addr uint64) (pcd *swift
 			}
 		case swift.GRKindLayout:
 			pcd.ConditionalRequirements[idx].Kind = swift.GenericRequirementLayoutKind(req.TypeOrProtocolOrConformanceOrLayoutOff.RelOff).String()
+		case swift.GRKindInvertedProtocols:
+			pcd.ConditionalRequirements[idx].Kind = swift.InvertibleProtocolSet(uint32(req.TypeOrProtocolOrConformanceOrLayoutOff.RelOff) >> 16).String()
 		default:
 			return nil, fmt.Errorf("unknown conditional requirement kind: %v", req.Flags.Kind())
 		}
@@ -2389,6 +2393,8 @@ func (f *File) parseGenericContext(ctx *swift.TypeGenericContext) (err error) {
 				if err != nil {
 					return fmt.Errorf("failed to read protocol conformance descriptor: %v", err)
 				}
+			case swift.GRKindInvertedProtocols:
+				ctx.Requirements[idx].Kind = swift.InvertibleProtocolSet(uint32(req.TypeOrProtocolOrConformanceOrLayoutOff.RelOff) >> 16).String()
 			case swift.GRKindLayout:
 				ctx.Requirements[idx].Kind = swift.GenericRequirementLayoutKind(req.TypeOrProtocolOrConformanceOrLayoutOff.RelOff).String()
 			default:

--- a/types/swift/protocols.go
+++ b/types/swift/protocols.go
@@ -208,9 +208,36 @@ const (
 	GRKindSameConformance GenericRequirementKind = 3 // same-conformance
 	// A same-shape requirement between generic parameter packs.
 	GRKSameShape GenericRequirementKind = 4 // same-shape
+	// A requirement that a generic parameter suppresses conformance to one or
+	// more invertible protocols (e.g. ~Copyable, ~Escapable). Added in Swift 6.
+	GRKindInvertedProtocols GenericRequirementKind = 5 // inverted-protocols
 	// A layout requirement.
 	GRKindLayout GenericRequirementKind = 0x1F // layout
 )
+
+// InvertibleProtocolSet is a bitset of the invertible protocols (Copyable,
+// Escapable) named by a GRKindInvertedProtocols generic requirement. The
+// requirement's payload word stores this set in its high 16 bits.
+type InvertibleProtocolSet uint16
+
+const (
+	InvertibleProtocolCopyable  InvertibleProtocolSet = 1 << 0 // Copyable
+	InvertibleProtocolEscapable InvertibleProtocolSet = 1 << 1 // Escapable
+)
+
+func (s InvertibleProtocolSet) String() string {
+	var parts []string
+	if s&InvertibleProtocolCopyable != 0 {
+		parts = append(parts, "~Copyable")
+	}
+	if s&InvertibleProtocolEscapable != 0 {
+		parts = append(parts, "~Escapable")
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("InvertibleProtocolSet(0x%x)", uint16(s))
+	}
+	return strings.Join(parts, " & ")
+}
 
 type GenericRequirementFlags uint32
 

--- a/types/swift/protocols_string.go
+++ b/types/swift/protocols_string.go
@@ -13,21 +13,22 @@ func _() {
 	_ = x[GRKindBaseClass-2]
 	_ = x[GRKindSameConformance-3]
 	_ = x[GRKSameShape-4]
+	_ = x[GRKindInvertedProtocols-5]
 	_ = x[GRKindLayout-31]
 }
 
 const (
-	_GenericRequirementKind_name_0 = "protocolsame-typebase-classsame-conformancesame-shape"
+	_GenericRequirementKind_name_0 = "protocolsame-typebase-classsame-conformancesame-shapeinverted-protocols"
 	_GenericRequirementKind_name_1 = "layout"
 )
 
 var (
-	_GenericRequirementKind_index_0 = [...]uint8{0, 8, 17, 27, 43, 53}
+	_GenericRequirementKind_index_0 = [...]uint8{0, 8, 17, 27, 43, 53, 71}
 )
 
 func (i GenericRequirementKind) String() string {
 	switch {
-	case i <= 4:
+	case i <= 5:
 		return _GenericRequirementKind_name_0[_GenericRequirementKind_index_0[i]:_GenericRequirementKind_index_0[i+1]]
 	case i == 31:
 		return _GenericRequirementKind_name_1


### PR DESCRIPTION
## Problem

Swift 6 introduced a new generic requirement kind, `InvertedProtocols` (`GenericRequirementKind` = 5), emitted for generic parameters that suppress conformance to an invertible protocol — i.e. `<T: ~Copyable>` and `~Escapable`.

The requirement parsers only handled kinds `0`–`4` and `0x1F` (`Layout`), so any **type, protocol, or conformance** whose generic signature carried a `~Copyable`/`~Escapable` constraint hit the `default:` arm and aborted Swift parsing:

```
⨯ failed to precache swift types: failed to read swift colocate type at address 0x...:
  ... failed to parse struct generic context: unknown generic requirement kind: GenericRequirementKind(5)
```

This truncates `ipsw macho info --swift` output for any binary built with a recent Swift 6 toolchain — including third-party SDKs vendored into otherwise-older apps. In one real-world iOS app binary it cut the recovered type tree from ~1,565 types down to ~1,058 (parsing stopped at the first such type).

Reported downstream as blacktop/ipsw#1234.

## Minimal repro

```swift
// repro.swift
public struct Box<T: ~Copyable>: ~Copyable {
    public var value: T
    public init(_ value: consuming T) { self.value = value }
}
public func makeBox() -> Int { Box<Int>(42).value }
```

```
xcrun swiftc -O repro.swift -o repro   # Swift 6.x toolchain
ipsw macho info --swift ./repro        # before: GenericRequirementKind(5) error; after: parses Box
```

## Fix

- Add `GRKindInvertedProtocols GenericRequirementKind = 5` + regenerate the stringer (`inverted-protocols`).
- Add an `InvertibleProtocolSet` helper that decodes the requirement payload into `~Copyable` / `~Escapable`.
- Handle the kind in all three requirement switches: protocol **signature** requirements, conditional-conformance requirements, and **generic-context** requirements.

### Payload encoding

Unlike the pointer-style kinds, `InvertedProtocols` stores the suppressed invertible-protocol set **inline in the high 16 bits** of the payload word (bit 0 = Copyable, bit 1 = Escapable). Verified empirically by compiling each variant:

| constraint | payload word | high-16 | decoded |
|---|---|---|---|
| `~Copyable` | `0x00010000` | `0x1` | `~Copyable` |
| `~Escapable` | `0x00020000` | `0x2` | `~Escapable` |
| `~Copyable & ~Escapable` | `0x00030000` | `0x3` | `~Copyable & ~Escapable` |

## Notes / out of scope

This restores the `--swift` type dump (the real-world binary above goes back to enumerating its full ~1,565-type tree, exit 0). The optional `PreCache()` colocate-walk of `__TEXT.__constg_swiftt` can still emit a *separate, non-fatal* warning on these binaries (`unknown swift type kind: ContextDescriptorKind(28)`) — that path walks the section sequentially and Swift 6's new generic-context trailing objects throw off its byte accounting. It does not affect the main `--swift` output (which reads types by address from `__swift5_types`). Left as a follow-up since correct trailing-object size accounting needs broader test coverage; happy to dig in separately if useful.

`go build ./...` and `go vet ./types/swift/` are clean; `gofmt` clean.